### PR TITLE
improve readme, ready to publish

### DIFF
--- a/factory.json
+++ b/factory.json
@@ -1,1 +1,1 @@
-{"name":"FiveStar","title":"Five Star","category":"data"}
+{"name":"FiveStar","title":"Five star rating editor","category":"data"}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wiki-plugin-fivestar",
-    "version": "0.1",
+    "version": "0.1.1",
     "description": "Federated Wiki - Five Star Rating Plug-in",
     "keywords": [
         "wiki",
@@ -12,22 +12,19 @@
         "email": "ben@pragmar.com",
         "url": "http://pragmar.com"
     },
-    "contributors": [],
+    "contributors": ["Ward Cunningham"],
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "license": "MIT",  
     "repository": {
         "type": "git",
-        "url": "https://github.com/pragmar/wiki-plugin-fivestar.git"
+        "url": "https://github.com/federated-wiki/wiki-plugin-fivestar.git"
     },
         "bugs": {
-        "url": "https://github.com/pragmar/wiki-plugin-fivestar/issues"
+        "url": "https://github.com/fedwrated-wiki/wiki-plugin-fivestar/issues"
     },
     "engines": {
     "node": "0.10"
-    },
-    "homepage": "http://pragmar.com",
-    "_id": "wiki-plugin-fivestar@20140710",
-    "_from": "wiki-plugin-fivestar@*"
+    }
 }

--- a/pages/about-fivestar-plugin
+++ b/pages/about-fivestar-plugin
@@ -1,17 +1,37 @@
 {
-  "title": "About Five Star",
+  "title": "About FiveStar Plugin",
   "story": [
     {
       "type": "paragraph",
       "id": "d2f89852e5065f0f",
-      "text": "FiveStar Plugin developed for Mike Caulfield's http://movienight.pw project to rate films. But why stop at films?"
+      "text": "FiveStar Plugin developed for Mike Caulfield's MovieNight project to rate films. But why stop at films?"
+    },
+    {
+      "type": "fivestar",
+      "id": "947cb8e17d957b87",
+      "text": "4"
+    },
+    {
+      "type": "paragraph",
+      "id": "59effee564873526",
+      "text": "When you create a FiveStar from the Factory menu you get a blank edit box which one would expect of a text markup. You have to type a number, 3 for three stars."
+    },
+    {
+      "type": "paragraph",
+      "id": "aa0350465b7c8e65",
+      "text": "After that you can edit the number by just clicking stars. This saves an action to the journal and forks the page (possibly to local storage) if need be."
+    },
+    {
+      "type": "paragraph",
+      "id": "c42bf096dae68b64",
+      "text": "Original work by Ben Caulfield, now hosted in the federated-wiki org. [https://github.com/federated-wiki/wiki-plugin-fivestar github]"
     }
   ],
   "journal": [
     {
       "type": "create",
       "item": {
-        "title": "About Five Star 2",
+        "title": "About FiveStar Plugin",
         "story": []
       },
       "date": 1405047813092
@@ -31,9 +51,73 @@
       "item": {
         "type": "paragraph",
         "id": "d2f89852e5065f0f",
-        "text": "FiveStar Plugin developed for Mike Caulfield's http://movienight.pw project to rate films. But why stop at films?"
+        "text": "FiveStar Plugin developed for Mike Caulfield's MovieNight project to rate films. But why stop at films?"
       },
       "date": 1405047864196
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "fivestar",
+        "id": "947cb8e17d957b87",
+        "text": "4"
+      },
+      "after": "d2f89852e5065f0f",
+      "id": "947cb8e17d957b87",
+      "date": 1492912225328
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "59effee564873526",
+        "text": "When you create a FiveStar from the Factory menu you get a blank edit box which one would expect of a text markup. You have to type a number, 3 for three stars."
+      },
+      "after": "947cb8e17d957b87",
+      "id": "59effee564873526",
+      "date": 1492912259448
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "aa0350465b7c8e65",
+        "text": "After that you can edit the number by just clicking stars. This saves an action to the journal and forks the page (possibly to local storage) if need be. "
+      },
+      "after": "59effee564873526",
+      "id": "aa0350465b7c8e65",
+      "date": 1492912262664
+    },
+    {
+      "type": "edit",
+      "id": "aa0350465b7c8e65",
+      "item": {
+        "type": "paragraph",
+        "id": "aa0350465b7c8e65",
+        "text": "After that you can edit the number by just clicking stars. This saves an action to the journal and forks the page (possibly to local storage) if need be."
+      },
+      "date": 1492912308152
+    },
+    {
+      "type": "add",
+      "id": "c42bf096dae68b64",
+      "item": {
+        "type": "paragraph",
+        "id": "c42bf096dae68b64",
+        "text": "Original work by Ben Caulfield, now hosted in the federated-wiki org. "
+      },
+      "after": "aa0350465b7c8e65",
+      "date": 1492912355761
+    },
+    {
+      "type": "edit",
+      "id": "c42bf096dae68b64",
+      "item": {
+        "type": "paragraph",
+        "id": "c42bf096dae68b64",
+        "text": "Original work by Ben Caulfield, now hosted in the federated-wiki org. [https://github.com/federated-wiki/wiki-plugin-fivestar github]"
+      },
+      "date": 1492912391167
     }
   ]
 }


### PR DESCRIPTION
I've improved the about page and published this plugin to npm. Mostly I wanted to include an example of the plugin which is our convention. I also cleaned up some scars in the journal which must have been from manual editing. I was careful to keep the original edit dates.

![screen shot 2017-04-22 at 7 07 09 pm](https://cloud.githubusercontent.com/assets/12127/25310056/68bf268e-2790-11e7-8c51-f9c39e61b989.png)

I'm recorded as the owner of the npm package but I would be happy to transfer it to you if you would want to resume possession of this plugin.