### PR TITLE
add dimension to ratings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.bak
+node_modules
+status

--- a/client/fivestar.js
+++ b/client/fivestar.js
@@ -92,7 +92,7 @@
                 var data = el.star.attr('data-rating');
                 var item = wiki.getItem(el.container);
                 
-                item.text = data;
+                item.stars = data;
                 save(el.container, item);
                 render();
             
@@ -108,7 +108,7 @@
         $('.fivestar').each(function(index, value){
             var _this = $(this);
             var item = wiki.getItem(_this);
-            var stars = item.text;
+            var stars = item.stars || parseInt(item.text) || 0;
             // set yellow stars to stored vales and kill active hover 
             $('.star.stored',_this).css('opacity', '0');
             $('.star.stored:lt('+stars+')', _this).css('opacity', '1');

--- a/client/fivestar.js
+++ b/client/fivestar.js
@@ -98,6 +98,13 @@
             
             });
         });
+
+        container.addClass('radar-source')
+        container.get(0).radarData = function(){
+            data = {}
+            data[item.text] = parseInt(item.stars)
+            return data
+        }
         
         render();
         return container;

--- a/client/fivestar.js
+++ b/client/fivestar.js
@@ -73,6 +73,7 @@
                 var rating = el.star.attr('data-rating');
                 $('.star.hover', el.container).css('opacity', '0');
                 $('.star.hover:lt('+rating+')', el.container).css('opacity', '1');
+                container.trigger('thumb', item.text)
                 
             });
             

--- a/client/fivestar.js
+++ b/client/fivestar.js
@@ -94,6 +94,7 @@
                 var item = wiki.getItem(el.container);
                 
                 item.stars = data;
+                item.key = item.text.split("\n")[0]
                 save(el.container, item);
                 render();
             

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-fivestar",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Federated Wiki - Five Star Rating Plug-in",
   "keywords": [
     "wiki",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-fivestar",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Federated Wiki - Five Star Rating Plug-in",
   "keywords": [
     "wiki",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-fivestar",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Federated Wiki - Five Star Rating Plug-in",
   "keywords": [
     "wiki",
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "async": "^2.4.0",
+    "csv-write-stream": "^2.0.0",
     "glob": "^7.1.1",
     "jsonfile": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-fivestar",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Federated Wiki - Five Star Rating Plug-in",
   "keywords": [
     "wiki",

--- a/package.json
+++ b/package.json
@@ -1,30 +1,37 @@
 {
-    "name": "wiki-plugin-fivestar",
-    "version": "0.1.1",
-    "description": "Federated Wiki - Five Star Rating Plug-in",
-    "keywords": [
-        "wiki",
-        "federated wiki",
-        "plugin"
-    ],
-    "author": {
-        "name": "Ben Caulfield",
-        "email": "ben@pragmar.com",
-        "url": "http://pragmar.com"
-    },
-    "contributors": ["Ward Cunningham"],
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "license": "MIT",  
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/federated-wiki/wiki-plugin-fivestar.git"
-    },
-        "bugs": {
-        "url": "https://github.com/fedwrated-wiki/wiki-plugin-fivestar/issues"
-    },
-    "engines": {
+  "name": "wiki-plugin-fivestar",
+  "version": "0.2.0",
+  "description": "Federated Wiki - Five Star Rating Plug-in",
+  "keywords": [
+    "wiki",
+    "federated wiki",
+    "plugin"
+  ],
+  "author": {
+    "name": "Ben Caulfield",
+    "email": "ben@pragmar.com",
+    "url": "http://pragmar.com"
+  },
+  "contributors": [
+    "Ward Cunningham"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/federated-wiki/wiki-plugin-fivestar.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fedwrated-wiki/wiki-plugin-fivestar/issues"
+  },
+  "engines": {
     "node": "0.10"
-    }
+  },
+  "dependencies": {
+    "async": "^2.4.0",
+    "glob": "^7.1.1",
+    "jsonfile": "^3.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-fivestar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Federated Wiki - Five Star Rating Plug-in",
   "keywords": [
     "wiki",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-fivestar",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Federated Wiki - Five Star Rating Plug-in",
   "keywords": [
     "wiki",

--- a/pages/about-fivestar-plugin
+++ b/pages/about-fivestar-plugin
@@ -9,17 +9,26 @@
     {
       "type": "fivestar",
       "id": "947cb8e17d957b87",
-      "text": "4"
+      "text": "Rating",
+      "stars": "3"
     },
     {
       "type": "paragraph",
       "id": "59effee564873526",
-      "text": "When you create a FiveStar from the Factory menu you get a blank edit box which one would expect of a text markup. You have to type a number, 3 for three stars."
+      "text": "Markup the plugin with the name of the property being rated. This should be one line, written in Title Case, no punctuation or newline."
     },
     {
       "type": "paragraph",
-      "id": "aa0350465b7c8e65",
-      "text": "After that you can edit the number by just clicking stars. This saves an action to the journal and forks the page (possibly to local storage) if need be."
+      "id": "e4b72d44c3ae3baf",
+      "text": "We've created a sample site that uses a Template to define multiple scales for rating cities. Explore there to see how FiveStar works with other wiki data capabilities."
+    },
+    {
+      "type": "reference",
+      "id": "d8fccd7e8a388d41",
+      "site": "best.ward.bay.wiki.org",
+      "slug": "best-cities",
+      "title": "Best Cities",
+      "text": "Here we list some well known cities, create pages for them with a template, and then rate them on many dimensions clicking stars. Results are automatically aggregated as a single file. [http://best.ward.bay.wiki.org/plugin/fivestar/slugs json]"
     },
     {
       "type": "paragraph",
@@ -118,6 +127,99 @@
         "text": "Original work by Ben Caulfield, now hosted in the federated-wiki org. [https://github.com/federated-wiki/wiki-plugin-fivestar github]"
       },
       "date": 1492912391167
+    },
+    {
+      "type": "edit",
+      "id": "947cb8e17d957b87",
+      "item": {
+        "type": "fivestar",
+        "id": "947cb8e17d957b87",
+        "text": "Rating"
+      },
+      "date": 1494596054547
+    },
+    {
+      "type": "edit",
+      "id": "947cb8e17d957b87",
+      "item": {
+        "type": "fivestar",
+        "id": "947cb8e17d957b87",
+        "text": "Rating",
+        "stars": "3"
+      },
+      "date": 1494596057646
+    },
+    {
+      "type": "edit",
+      "id": "59effee564873526",
+      "item": {
+        "type": "paragraph",
+        "id": "59effee564873526",
+        "text": "Markup the plugin with the name of the property being rated. This should be one line, written in Title Case, no punctuation or newline."
+      },
+      "date": 1494596256297
+    },
+    {
+      "type": "remove",
+      "id": "aa0350465b7c8e65",
+      "date": 1494596336670
+    },
+    {
+      "type": "add",
+      "id": "e4b72d44c3ae3baf",
+      "item": {
+        "type": "paragraph",
+        "id": "e4b72d44c3ae3baf",
+        "text": "We've created a sample site that uses a Template to define multiple scales for rating cities. Explore there to see how FiveStar works with other wiki data capabilities. [http://best.ward.bay.wiki.org/ site]"
+      },
+      "after": "59effee564873526",
+      "date": 1494596547478
+    },
+    {
+      "type": "edit",
+      "id": "e4b72d44c3ae3baf",
+      "item": {
+        "type": "paragraph",
+        "id": "e4b72d44c3ae3baf",
+        "text": "We've created a sample site that uses a Template to define multiple scales for rating cities. Explore there to see how FiveStar works with other wiki data capabilities."
+      },
+      "date": 1494596565968
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "d8fccd7e8a388d41"
+      },
+      "id": "d8fccd7e8a388d41",
+      "type": "add",
+      "after": "c42bf096dae68b64",
+      "date": 1494596572043
+    },
+    {
+      "type": "edit",
+      "id": "d8fccd7e8a388d41",
+      "item": {
+        "type": "reference",
+        "id": "d8fccd7e8a388d41",
+        "site": "best.ward.bay.wiki.org",
+        "slug": "best-cities",
+        "title": "Best Cities",
+        "text": "Here we list some well known cities, create pages for them with a template, and then rate them on many dimensions clicking stars. Results are automatically aggregated as a single file. [http://best.ward.bay.wiki.org/plugin/fivestar/slugs json]"
+      },
+      "date": 1494596591794
+    },
+    {
+      "type": "move",
+      "order": [
+        "d2f89852e5065f0f",
+        "947cb8e17d957b87",
+        "59effee564873526",
+        "e4b72d44c3ae3baf",
+        "d8fccd7e8a388d41",
+        "c42bf096dae68b64"
+      ],
+      "id": "d8fccd7e8a388d41",
+      "date": 1494596605426
     }
   ]
 }

--- a/pages/about-fivestar-plugin
+++ b/pages/about-fivestar-plugin
@@ -28,7 +28,7 @@
       "site": "best.ward.bay.wiki.org",
       "slug": "best-cities",
       "title": "Best Cities",
-      "text": "Here we list some well known cities, create pages for them with a template, and then rate them on many dimensions clicking stars. Results are automatically aggregated as a single file. [http://best.ward.bay.wiki.org/plugin/fivestar/slugs json]"
+      "text": "Here we list some well known cities, create pages for them with a template, and then rate them on many dimensions clicking stars. Results are automatically aggregated as a single file. [http://best.ward.bay.wiki.org/plugin/fivestar/ratings.json json]"
     },
     {
       "type": "paragraph",
@@ -204,7 +204,7 @@
         "site": "best.ward.bay.wiki.org",
         "slug": "best-cities",
         "title": "Best Cities",
-        "text": "Here we list some well known cities, create pages for them with a template, and then rate them on many dimensions clicking stars. Results are automatically aggregated as a single file. [http://best.ward.bay.wiki.org/plugin/fivestar/slugs json]"
+        "text": "Here we list some well known cities, create pages for them with a template, and then rate them on many dimensions clicking stars. Results are automatically aggregated as a single file. [http://best.ward.bay.wiki.org/plugin/fivestar/ratings.json json]"
       },
       "date": 1494596591794
     },

--- a/pages/about-fivestar-plugin
+++ b/pages/about-fivestar-plugin
@@ -15,7 +15,7 @@
     {
       "type": "paragraph",
       "id": "59effee564873526",
-      "text": "Markup the plugin with the name of the property being rated. This should be one line, written in Title Case, no punctuation or newline."
+      "text": "Markup the plugin with the name of the property being rated. This should be one line, written in Title Case."
     },
     {
       "type": "paragraph",
@@ -155,7 +155,7 @@
       "item": {
         "type": "paragraph",
         "id": "59effee564873526",
-        "text": "Markup the plugin with the name of the property being rated. This should be one line, written in Title Case, no punctuation or newline."
+        "text": "Markup the plugin with the name of the property being rated. This should be one line, written in Title Case."
       },
       "date": 1494596256297
     },

--- a/server/server.js
+++ b/server/server.js
@@ -9,21 +9,12 @@
   function startServer(params) {
     var app = params.app
     var argv = params.argv
-    app.get('/plugin/fivestar/details/:stars/:stripes', details)
-    app.get('/plugin/fivestar/slugs', slugs)
+    app.get('/plugin/fivestar/ratings.json', ratings)
 
-    function details(req, res) {
-      var report = {}
-      report.req = Object.keys(req)
-      report.params = req.params
-      report.query = req.query
-      return res.send("<pre>" + (JSON.stringify(report, null, '  ')))
-    }
-
-    function slugs(req, res) {
+    function ratings(req, res) {
       var report = {}
 
-      glob(argv.db+'/*', { cwd: argv.packageDir }, allfiles)
+      glob('*', { cwd: argv.db }, allfiles)
 
       function allfiles(err, files) {
         if (err) return done(err)
@@ -31,7 +22,7 @@
       }
 
       function eachfile(file, done) {
-        jsonfile.readFile(file, {throws:false}, eachpage)
+        jsonfile.readFile(argv.db + '/' + file, {throws:false}, eachpage)
 
         function eachpage(err, page) {
           if (err) return done(err)
@@ -43,7 +34,7 @@
             var item = story[i]
             if(item && item.type && item.type == 'fivestar') {
               if(item.stars) {
-                stars[item.text||'unlabled'] = item.stars
+                stars[item.text||'unlabled'] = parseInt(item.stars)
               }
             }
           }
@@ -56,7 +47,8 @@
 
       function done(err) {
         if (err) return res.send(err.message)
-        res.send("<pre>" + (JSON.stringify(report, null, '  ')))
+        res.set({'Content-type': 'application/json'})
+        res.send(report)
       }
     }
 

--- a/server/server.js
+++ b/server/server.js
@@ -5,25 +5,57 @@
   var glob = require('glob')
   var async = require('async')
   var jsonfile = require('jsonfile')
+  var csvWriter = require('csv-write-stream')
 
   function startServer(params) {
     var app = params.app
     var argv = params.argv
-    app.get('/plugin/fivestar/ratings.json', ratings)
+    app.get('/plugin/fivestar/ratings.json', ratingsJson)
+    app.get('/plugin/fivestar/ratings.csv', ratingsCsv)
 
-    function ratings(req, res) {
+    function ratingsCsv(req, res) {
+      collectRatings(collectDone)
+      function collectDone(err, report) {
+        var heading = {}
+        for (var page in report) {
+          for (var rating in report[page]) {
+            heading[rating] = true
+          }
+        }
+        var headers = Object.keys(heading)
+        var writer = csvWriter({headers: ['Title'].concat(headers)})
+        writer.pipe(res)
+        for (var page in report) {
+          var row = report[page]
+          writer.write([page].concat(headers.map(val)))
+          function val(key) {return row[key]}
+        }
+        writer.end()
+      }
+    }
+
+    function ratingsJson(req, res) {
+      collectRatings(collectDone)
+      function collectDone(err, report) {
+        if (err) return res.send(err.message)
+        res.set({'Content-type': 'application/json'})
+        res.send(report)
+      }
+    }
+
+    function collectRatings(ratingsDone) {
       var report = {}
-
       glob('*', { cwd: argv.db }, allfiles)
-
       function allfiles(err, files) {
         if (err) return done(err)
-        async.map(files||[], eachfile, done) 
+        async.map(files||[], eachfile, allfilesDone)
       }
-
-      function eachfile(file, done) {
+      function allfilesDone(err) {
+        if (err) return ratingsDone(err)
+        ratingsDone(null, report)
+      }
+      function eachfile(file, eachFileDone) {
         jsonfile.readFile(argv.db + '/' + file, {throws:false}, eachpage)
-
         function eachpage(err, page) {
           if (err) return done(err)
           var title = page.title || 'untitled'
@@ -41,19 +73,11 @@
           if(Object.keys(stars).length) {
             report[title] = stars
           }
-          done (null, title)
+          eachFileDone(null, title)
         }
       }
-
-      function done(err) {
-        if (err) return res.send(err.message)
-        res.set({'Content-type': 'application/json'})
-        res.send(report)
-      }
     }
-
   }
-
 
   module.exports = {
     startServer: startServer

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,70 @@
+(function() {
+
+  var fs = require('fs')
+  var path = require('path')
+  var glob = require('glob')
+  var async = require('async')
+  var jsonfile = require('jsonfile')
+
+  function startServer(params) {
+    var app = params.app
+    var argv = params.argv
+    app.get('/plugin/fivestar/details/:stars/:stripes', details)
+    app.get('/plugin/fivestar/slugs', slugs)
+
+    function details(req, res) {
+      var report = {}
+      report.req = Object.keys(req)
+      report.params = req.params
+      report.query = req.query
+      return res.send("<pre>" + (JSON.stringify(report, null, '  ')))
+    }
+
+    function slugs(req, res) {
+      var report = {}
+
+      glob(argv.db+'/*', { cwd: argv.packageDir }, allfiles)
+
+      function allfiles(err, files) {
+        if (err) return done(err)
+        async.map(files||[], eachfile, done) 
+      }
+
+      function eachfile(file, done) {
+        jsonfile.readFile(file, {throws:false}, eachpage)
+
+        function eachpage(err, page) {
+          if (err) return done(err)
+          var title = page.title || 'untitled'
+          var story = page.story || []
+          var synop = (page.story[0]||{}).text || 'empty'
+          var stars = {}
+          for (var i=0; i<story.length; i++) {
+            var item = story[i]
+            if(item && item.type && item.type == 'fivestar') {
+              if(item.stars) {
+                stars[item.text||'unlabled'] = item.stars
+              }
+            }
+          }
+          if(Object.keys(stars).length) {
+            report[title] = stars
+          }
+          done (null, title)
+        }
+      }
+
+      function done(err) {
+        if (err) return res.send(err.message)
+        res.send("<pre>" + (JSON.stringify(report, null, '  ')))
+      }
+    }
+
+  }
+
+
+  module.exports = {
+    startServer: startServer
+  }
+
+}).call(this)

--- a/server/server.js
+++ b/server/server.js
@@ -66,7 +66,7 @@
             var item = story[i]
             if(item && item.type && item.type == 'fivestar') {
               if(item.stars) {
-                stars[item.text||'unlabled'] = parseInt(item.stars)
+                stars[item.key||item.text||'unlabled'] = parseInt(item.stars)
               }
             }
           }


### PR DESCRIPTION
This request addresses some of the issues raised in #3

We store ratings in the `stars` field of the item. This leaves `text` available for labeling.
A sample site this capability. http://best.ward.bay.wiki.org

![screen shot 2017-05-12 at 5 54 44 am](https://cloud.githubusercontent.com/assets/12127/26002481/9fc366d2-36e4-11e7-82c3-ff7b99343d69.png)
